### PR TITLE
Fix/transformable sprite

### DIFF
--- a/include/M3L/Rendering/Sprite.hpp
+++ b/include/M3L/Rendering/Sprite.hpp
@@ -23,12 +23,12 @@ namespace m3l
             void draw(RenderTarget &_target, const Texture *_txtr) const override;
 
         private:
-            void buildVertex();
             void processRect();
+            void buildVertex(bool _update = false) const;
 
             Texture *m_txtr = nullptr;
 
-            VertexArray m_vertex{};
+            mutable VertexArray m_vertex{};
 
             Rect m_rect;
     };

--- a/include/M3L/Rendering/Transformable.hpp
+++ b/include/M3L/Rendering/Transformable.hpp
@@ -26,7 +26,12 @@ namespace m3l
             void rotate(float _rot);
             [[nodiscard]] float getRotation() const;
 
+        protected:
+            [[nodiscard]] bool requiredUpdate() const;
+
         private:
+            mutable bool m_update = false;
+
             Point2<float> m_pos{};
             Point2<float> m_scale = { 1, 1 };
             float m_rotation = 0.f;

--- a/src/Rendering/Sprite.cpp
+++ b/src/Rendering/Sprite.cpp
@@ -30,6 +30,7 @@ namespace m3l
     {
         std::ignore = _txtr;
 
+        buildVertex();
         _target.draw(m_vertex, m_txtr);
     }
 
@@ -38,18 +39,21 @@ namespace m3l
         Point2<float> size = (m_txtr) ? m_txtr->getSize().as<float>() : Point2<float>(0.f , 0.f);
 
         m_rect = { getPosition(), size * getScale() };
-        buildVertex();
+        buildVertex(true);
     }
 
-    void Sprite::buildVertex()
+    void Sprite::buildVertex(bool _update) const
     {
         // known bug:
         // - when inversing the pos of the addition for vertex 2 and 4
         // - when inversing m_rect.size for vertex 2 and 4
-        m_vertex.clear();
-        m_vertex.append({ m_rect.pos, { 0, 0 } });
-        m_vertex.append({ { m_rect.pos.x + m_rect.size.x, m_rect.pos.y }, { m_rect.size.x, 0 } });
-        m_vertex.append({ m_rect.pos + m_rect.size, m_rect.size });
-        m_vertex.append({ { m_rect.pos.x, m_rect.pos.y + m_rect.size.y }, { 0, m_rect.size.y } });
+        if (_update || requiredUpdate())
+        {
+            m_vertex.clear();
+            m_vertex.append({ m_rect.pos, { 0, 0 } });
+            m_vertex.append({ { m_rect.pos.x + m_rect.size.x, m_rect.pos.y }, { m_rect.size.x, 0 } });
+            m_vertex.append({ m_rect.pos + m_rect.size, m_rect.size });
+            m_vertex.append({ { m_rect.pos.x, m_rect.pos.y + m_rect.size.y }, { 0, m_rect.size.y } });
+        }
     }
 }

--- a/src/Rendering/Transformable.cpp
+++ b/src/Rendering/Transformable.cpp
@@ -6,22 +6,26 @@ namespace m3l
     {
         m_pos.y = _x;
         m_pos.y = _y;
+        m_update = true;
     }
 
     void Transformable::setPosition(const Point2<float> &_pos)
     {
         m_pos = _pos;
+        m_update = true;
     }
 
     void Transformable::move(float _x, float _y)
     {
         m_pos.x += _x;
         m_pos.y += _y;
+        m_update = true;
     }
 
     void Transformable::move(const Point2<float> &_move)
     {
         m_pos += _move;
+        m_update = true;
     }
 
     const Point2<float> &Transformable::getPosition() const
@@ -38,11 +42,13 @@ namespace m3l
     {
         m_scale.x = _rh;
         m_scale.y = _rw;
+        m_update = true;
     }
 
     void Transformable::setScale(const Point2<float> &_scale)
     {
         m_scale = _scale;
+        m_update = true;
     }
 
     Point2<float> &Transformable::getScale()
@@ -59,15 +65,25 @@ namespace m3l
     void Transformable::setRotatio(float _rot)
     {
         m_rotation = _rot;
+        m_update = true;
     }
 
     void Transformable::rotate(float _rot)
     {
         m_rotation += _rot;
+        m_update = true;
     }
 
     float Transformable::getRotation() const
     {
         return m_rotation;
+    }
+
+    bool Transformable::requiredUpdate() const
+    {
+        if (!m_update)
+            return false;
+        m_update = false;
+        return true;
     }
 }


### PR DESCRIPTION
## Fix:

- `Sprite` apply the `Transformable` property during rendering.