### PR TITLE
Applying alpha between 2D and 3D

### DIFF
--- a/include/M3L/Graphics/Color.hpp
+++ b/include/M3L/Graphics/Color.hpp
@@ -5,8 +5,19 @@
 #include "Tool/Export.hpp"
 
 #define CLR(_clr)           (static_cast<uint32_t>(_clr.A) << 24) | (static_cast<uint32_t>(_clr.R) << 16) | (static_cast<uint32_t>(_clr.G) << 8) | _clr.B
-#define CLR_GET_ALPHA(_clr) ((_clr >> 24) & 0xFF)
-#define CLR_GET_RGB(_clr)   (_clr & 0xFFFFFF)
+
+#define CLR_GET_RGB(_clr)           (_clr & 0xFFFFFF)
+#define CLR_GET_BLUE(_clr)          (_clr & 0xFF)
+#define CLR_GET_GREEN(_clr)         ((_clr >> 8) & 0xFF)
+#define CLR_GET_RED(_clr)           ((_clr >> 16) & 0xFF)
+#define CLR_GET_ALPHA(_clr)         ((_clr >> 24) & 0xFF)
+
+#define CLR_SET_BLUE(_clr, _blue)   _clr = (_blue & 0xFF)           | (_clr & 0xFFFFFF00) 
+#define CLR_SET_GREEN(_clr, _green) _clr = ((_green & 0xFF) << 8)   | (_clr & 0xFFFF00FF) 
+#define CLR_SET_RED(_clr, _red)     _clr = ((_red & 0xFF) << 16)    | (_clr & 0xFF00FFFF) 
+#define CLR_SET_ALPHA(_clr, _alpha) _clr = ((_alpha & 0xFF) << 24)  | (_clr & 0x00FFFFFF) 
+
+#define CLR_RATIO_ALPHA(_clr)       (static_cast<float>(CLR_GET_ALPHA(_clr)) / 255.f)
 
 namespace m3l
 {
@@ -21,4 +32,6 @@ namespace m3l
     };
 
     M3L_API std::ostream &operator<<(std::ostream &_os, const Color &_clr);
+
+    uint32_t applyAlpha(uint32_t _new, uint32_t _old);
 }

--- a/src/Graphics/Color.cpp
+++ b/src/Graphics/Color.cpp
@@ -19,4 +19,20 @@ namespace m3l
             << ", " << static_cast<uint16_t>(_clr.B) << ", " << static_cast<uint16_t>(_clr.A) << " }";
         return _os;
     }
+
+    uint32_t applyAlpha(uint32_t _new, uint32_t _old)
+    {
+        uint32_t clr{};
+        float old_alpha = CLR_RATIO_ALPHA(_old);
+        float new_alpha = CLR_RATIO_ALPHA(_new);
+
+        CLR_SET_ALPHA(clr, static_cast<uint8_t>((1 - (1 - old_alpha) * (1 - new_alpha)) * 255.f));
+        float new_ratio = new_alpha / CLR_RATIO_ALPHA(clr);
+        float old_ratio = old_alpha * (1 - new_alpha) / CLR_GET_ALPHA(clr);
+
+        CLR_SET_RED(clr, static_cast<uint8_t>(CLR_GET_RED(_new) * new_ratio + CLR_GET_RED(_old) * old_ratio));
+        CLR_SET_GREEN(clr, static_cast<uint8_t>(CLR_GET_GREEN(_new) * new_ratio + CLR_GET_GREEN(_old) * old_ratio));
+        CLR_SET_BLUE(clr, static_cast<uint8_t>(CLR_GET_BLUE(_new) * new_ratio + CLR_GET_BLUE(_old) * old_ratio));
+        return clr;
+    }
 }

--- a/src/Graphics/Target/BaseRenderWindow.cpp
+++ b/src/Graphics/Target/BaseRenderWindow.cpp
@@ -48,11 +48,13 @@ namespace m3l
         bmi.bmiHeader.biBitCount = RenderTarget2D::getBpp();
         bmi.bmiHeader.biCompression = BI_RGB;
         for (size_t it = 0; it < size.x * size.y; it++) {
-            // alpha is broken
-            //if (CLR_GET_ALPHA(data2d[it]) == 0)
-            data[it] = data3d[it];
-            //else
-            // data[it] = data2d[it];
+            if (CLR_GET_ALPHA(data2d[it]) == 0) {
+                data[it] = data3d[it];
+            } else if (CLR_GET_ALPHA(data3d[it]) == 0) {
+                data[it] = data2d[it];
+            } else {
+               data[it] = applyAlpha(data2d[it], data3d[it]);
+            }
         }
         SetDIBitsToDevice(_draw, 0, 0, size.x, size.y, 0, 0, 0, size.y, data.data(), &bmi, DIB_RGB_COLORS);
     }


### PR DESCRIPTION
## Features:

- `applyAlpha` function to merge 2 pixel using alpha.

### Macro:

- `CLR_GET_RGB`, `CLR_GET_BLUE`, `CLR_GET_RED`, `CLR_GET_GREEN`, `CLR_GET_ALPHA`: get the representing value out of a **color** from an `uint32_t` (_no type checking_)
-  `CLR_SET_RGB`, `CLR_SET_BLUE`, `CLR_SET_RED`, `CLR_SET_GREEN`, `CLR_SET_ALPHA`: set the representing value in a **color** from an `uint32_t` (_no type checking_)
- `CLR_RATIO_ALPHA`: get the ratio of alpha (_/255_) as a float from a **color** as `uint32_t` (_no type checking_)